### PR TITLE
Support format option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ The directory to put the DMG into. [Default: `process.cwd()`].
 `icon-size` - *Number*
 How big to make the icon for the app in the DMG. [Default: `80`].
 
+`format` - *String*
+Disk image format. [Default: `UDZO`].
+
+[Must be one of the following][spec]:
+
+- `UDRW` :arrow_right: read/write image
+- `UDRO` :arrow_right: read-only image
+- `UDCO` :arrow_right: ADC-compressed image
+- `UDZO` :arrow_right: zlib-compressed image
+- `UDBZ` :arrow_right: bzip2-compressed image
+- `ULFO` :arrow_right: lzfse-compressed image (macOS 10.11+ only)
+
+
 ##### callback
 
 `err` - *Error*
@@ -85,3 +98,4 @@ Apache 2.0
 [npm_url]: https://npmjs.org/package/electron-installer-dmg
 [electron-packager]: https://github.com/maxogden/electron-packager
 [appdmg]: https://github.com/LinusU/node-appdmg
+[spec]: https://github.com/LinusU/node-appdmg#specification

--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ function build(opts, done) {
     contents: opts.contents,
     icon: opts.icon,
     'icon-size': opts['icon-size'],
-    background: opts.background
+    background: opts.background,
+    format: opts.format
   };
   var contents = JSON.stringify(spec, null, 2);
 
@@ -62,12 +63,14 @@ module.exports = function(opts, done) {
   }
 
   opts['icon-size'] = opts['icon-size'] || 80;
-  opts['out'] = opts['out'] || process.cwd();
-  
+  opts.out = opts.out || process.cwd();
+
   opts.appPath = path.resolve(process.cwd(), opts.appPath);
   opts.dmgPath = path.resolve(opts.dmgPath || path.join(opts.out, opts.name + '.dmg'));
 
   opts.overwrite = opts.overwrite || false;
+
+  opts.format = opts.format || 'UDZO';
 
   opts.contents = opts.contents || [
     {

--- a/usage.txt
+++ b/usage.txt
@@ -10,6 +10,7 @@ Options:
   --icon=<path>        Path to the icon file that will be the app icon in the DMG window.
   --icon-size=<px>     How big to make the icon for the app in the DMG. [Default: `80`].
   --background=<path>  Path to a PNG image to use as the background of the DMG.
+  --format=<format>    Disk image format. [Default: `UDZO`].
   --debug              Enable debug messages.
   --overwrite          Overwrite any existing DMG.
   -h --help            Show this screen.


### PR DESCRIPTION
Allow specifying the `format` option for [appdmg][spec]:

- `UDRW` :arrow_right: read/write image
- `UDRO` :arrow_right: read-only image
- `UDCO` :arrow_right: ADC-compressed image
- `UDZO` :arrow_right: zlib-compressed image
- `UDBZ` :arrow_right: bzip2-compressed image
- `ULFO` :arrow_right: lzfse-compressed image (macOS 10.11+ only)

Requested in #8 

[spec]: https://github.com/LinusU/node-appdmg#specification
