### PR TITLE
Fix os.tmpDir() deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function build(opts, done) {
 
   debug('DMG spec is:\n', spec);
 
-  var src = path.resolve(os.tmpDir(), 'appdmg.json');
+  var src = path.resolve(os.tmpdir(), 'appdmg.json');
   debug('writing config to `%s`', src);
 
   fs.writeFile(src, contents, function(err) {


### PR DESCRIPTION
Update `src` to use `os.tmpdir()` as `os.tmpDir()` is now marked as deprecated

Running `electron-installer-dmg` shows the following deprecation warning:
`DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead`

#11