### PR TITLE
Set os to darwin in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "mongodb-js-precommit": "^0.2.9",
     "pre-commit": "^1.0.10"
   },
+  "os": [
+    "darwin"
+  ],
   "keywords": [
     "mongodb.js",
     "electron",


### PR DESCRIPTION
This package currently only works on MacOS, so indicate that in package.json.

I believe this will work around [this](https://github.com/electron-userland/electron-forge/issues/136) bug and allow using yarn with electron-forge on linux, or more generally allow using yarn on any project that has electron-installer-dmg as a dependency on linux.